### PR TITLE
Better checks on storage sources

### DIFF
--- a/src/prototype/room.resources.ts
+++ b/src/prototype/room.resources.ts
@@ -591,6 +591,10 @@ Room.prototype.getBestCircumstancialStorageSource = function (this: Room, resour
 		secondarySource = this.storage;
 	}
 
+	if(!secondarySource) {
+		return primarySource;
+	}
+	
 	const secondaryFull = secondarySource.store.getUsedCapacity() > secondarySource.store.getCapacity() * 0.8;
 
 	if (primarySource.store[resourceType] && (!secondaryFull || !secondarySource.store[resourceType])) {


### PR DESCRIPTION
Secondary storage sources are not always available. If no secondar storage source exists, we should return primary source instead.