### PR TITLE
Transport cleanup

### DIFF
--- a/src/dispatcher/resource-source/dispatcher.ts
+++ b/src/dispatcher/resource-source/dispatcher.ts
@@ -5,6 +5,8 @@ import LabSource from 'dispatcher/resource-source/lab';
 import LinkSource from 'dispatcher/resource-source/link';
 import StorageSource from 'dispatcher/resource-source/storage';
 import TerminalSource from 'dispatcher/resource-source/terminal';
+import GraveSource from "./grave";
+import DropSource from "./drop";
 
 declare global {
 	interface ResourceSourceTask extends Task {
@@ -14,7 +16,7 @@ declare global {
 
 	interface ResourceSourceContext {
 		resourceType?: ResourceConstant;
-		creep: Creep;
+		creep?: Creep;
 	}
 }
 
@@ -27,5 +29,7 @@ export default class ResourceSourceDispatcher extends Dispatcher<ResourceSourceT
 		this.addProvider(new LinkSource(room));
 		this.addProvider(new StorageSource(room));
 		this.addProvider(new TerminalSource(room));
+		this.addProvider(new DropSource(room));
+		this.addProvider(new GraveSource(room));
 	}
 }

--- a/src/dispatcher/resource-source/drop.ts
+++ b/src/dispatcher/resource-source/drop.ts
@@ -1,0 +1,112 @@
+import TaskProvider from '../task-provider';
+import { ENEMY_STRENGTH_NONE } from '../../room-defense';
+import { getDangerMatrix } from '../../utils/cost-matrix';
+
+interface DropSourceTask extends ResourceSourceTask {
+  type: 'drop';
+  target: Id<Resource>;
+}
+
+export default class DropSource implements TaskProvider<DropSourceTask, ResourceSourceTask> {
+  constructor(readonly room: Room) {
+  }
+
+  getType(): 'drop' {
+    return 'drop';
+  }
+
+  getHighestPriority() {
+    return 7;
+  }
+
+  getTasks(context: ResourceSourceContext) {
+    const options: DropSourceTask[] = [];
+
+    this.addObjectResourceOptions(options, FIND_DROPPED_RESOURCES, context);
+
+    return options;
+  }
+
+  /**
+   * Adds options for picking up resources from certain objects to priority list.
+   *
+   * @param {Array} options
+   *   A list of potential resource sources.
+   * @param {String} findConstant
+   *   The type of find operation to run, e.g. FIND_DROPPED_RESOURCES.
+   */
+  addObjectResourceOptions(options: DropSourceTask[], findConstant: FIND_DROPPED_RESOURCES, context: ResourceSourceContext) {
+    const creep = context.creep;
+    const resourceType = context.resourceType;
+
+    // Look for resources on the ground.
+    const targets = creep.room.find(findConstant, {
+      filter: target => {
+        if (!this.isSafePosition(creep as Creep, target.pos)) return false;
+
+        if (resourceType && resourceType != target.resourceType) return false;
+
+        if (target.amount > 10) {
+          const result = PathFinder.search(creep.pos, target.pos);
+          if (!result.incomplete) return true;
+        }
+
+        return false;
+      }
+    });
+
+    for (const target of targets) {
+      // const store = target instanceof Resource ? {[target.resourceType]: target.amount} : target.store;
+      const resourceType = target.resourceType;
+      // if (resourceType === RESOURCE_ENERGY) continue;
+
+      const option = {
+        priority: 5,
+        weight: target.amount / 30, // @todo Also factor in distance.
+        type: this.getType(),
+        target: target.id,
+        resourceType
+      };
+
+      if (resourceType === RESOURCE_POWER) {
+        option.priority++;
+      }
+      if (resourceType === RESOURCE_ENERGY) {
+        option.priority += 2;
+      }
+
+      if (target.amount < creep.store.getCapacity() * 2) {
+        option.priority -= creep.room.getCreepsWithOrder(this.getType(), target.id).length * 2;
+      }
+
+      options.push(option);
+    }
+  }
+
+  isSafePosition(creep: Creep, pos: RoomPosition): boolean {
+    if (!creep.room.isMine()) return true;
+    if (creep.room.defense.getEnemyStrength() === ENEMY_STRENGTH_NONE) return true;
+
+    const matrix = getDangerMatrix(creep.room.name);
+    if (matrix.get(pos.x, pos.y) > 0) return false;
+
+    return true;
+  }
+
+  isValid(task: DropSourceTask, context: ResourceSourceContext) {
+    const target = Game.getObjectById(task.target);
+    if (!target) return false;
+    if (target.amount < context.creep.store.getFreeCapacity() / 4) return false;
+
+    return true;
+  }
+
+  execute(task: DropSourceTask, context: ResourceSourceContext) {
+    const creep = context.creep;
+    const target = Game.getObjectById(task.target);
+    creep.whenInRange(1, target, () => {
+      creep.pickup(target);
+      delete creep.memory.order;
+    });
+  }
+}

--- a/src/dispatcher/resource-source/grave.ts
+++ b/src/dispatcher/resource-source/grave.ts
@@ -1,0 +1,124 @@
+import { ENEMY_STRENGTH_NONE } from '../../room-defense';
+import { getDangerMatrix } from '../../utils/cost-matrix';
+import StructureSource from './structure';
+import { getResourcesIn } from '../../utils/store';
+
+interface GraveSourceTask extends StructureSourceTask {
+  type: 'grave';
+  target: Id<Ruin | Tombstone>;
+}
+
+export default class GraveSource extends StructureSource<GraveSourceTask> {
+  constructor(readonly room: Room) {
+    super(room);
+  }
+
+  getType(): 'grave' {
+    return 'grave';
+  }
+
+  getHighestPriority() {
+    return 4;
+  }
+
+  getTasks(context: ResourceSourceContext) {
+    const options: GraveSourceTask[] = [];
+
+    this.addObjectResourceOptions(options, FIND_RUINS, context);
+    this.addObjectResourceOptions(options, FIND_TOMBSTONES, context);
+
+    return options;
+  }
+
+  /**
+   * Adds options for picking up resources from certain objects to priority list.
+   *
+   * @param {Array} options
+   *   A list of potential resource sources.
+   * @param {String} findConstant
+   *   The type of find operation to run, e.g. FIND_DROPPED_RESOURCES.
+   */
+  addObjectResourceOptions(options: GraveSourceTask[], findConstant: FIND_RUINS | FIND_TOMBSTONES, context: ResourceSourceContext) {
+    const creep = context.creep;
+    const resourceType = context.resourceType;
+
+    // Look for resources on the ground.
+    const targets = creep.room.find(findConstant, {
+      filter: target => {
+        if (!this.isSafePosition(creep as Creep, target.pos)) return false;
+
+        if (target.store.getUsedCapacity() < 10) return false;
+        if (resourceType && target.store.getUsedCapacity(resourceType) < 10) return false;
+
+        const result = PathFinder.search(creep.pos, target.pos);
+        if (!result.incomplete) return true;
+
+        return false;
+      }
+    });
+
+    for (const target of targets) {
+      for (const resourceType of getResourcesIn(target.store)) {
+
+        const option = {
+          priority: 4,
+          weight: target.store.getUsedCapacity(resourceType) / 30, // @todo Also factor in distance.
+          type: this.getType(),
+          target: target.id,
+          resourceType
+        };
+
+        if (target.ticksToDecay < 100) option.priority++;
+
+        if (resourceType === RESOURCE_POWER) {
+          option.priority++;
+        }
+        if (resourceType === RESOURCE_ENERGY) {
+          option.priority += 2;
+        }
+
+        if (target.store.getUsedCapacity(resourceType) < creep.store.getCapacity() * 2) {
+          option.priority -= creep.room.getCreepsWithOrder(this.getType(), target.id).length * 2;
+        }
+
+        options.push(option);
+      }
+    }
+  }
+
+  isSafePosition(creep: Creep, pos: RoomPosition): boolean {
+    if (!creep.room.isMine()) return true;
+    if (creep.room.defense.getEnemyStrength() === ENEMY_STRENGTH_NONE) return true;
+
+    const matrix = getDangerMatrix(creep.room.name);
+    if (matrix.get(pos.x, pos.y) > 0) return false;
+
+    return true;
+  }
+
+  isValid(task: GraveSourceTask, context: ResourceSourceContext) {
+    const target = Game.getObjectById(task.target);
+    if (!target) return false;
+    if (target.store.getUsedCapacity(task.resourceType) === 0) return false;
+    if (context.creep.store.getFreeCapacity(task.resourceType) === 0) return false;
+    if (!this.isSafePosition(context.creep, target.pos)) return false;
+
+    return true;
+  }
+
+  execute(task: GraveSourceTask, context: ResourceSourceContext) {
+    const creep = context.creep;
+    const target = Game.getObjectById(task.target);
+    creep.whenInRange(1, target, () => {
+      const resourceType = task.resourceType;
+
+      let result;
+      if (task.amount)
+        result = creep.withdraw(target, resourceType, Math.min(target.store.getUsedCapacity(resourceType), task.amount, creep.store.getFreeCapacity()));
+      else
+        result = creep.withdraw(target, resourceType);
+
+      if (result != OK) delete creep.memory.order;
+    });
+  }
+}

--- a/src/dispatcher/resource-source/structure.ts
+++ b/src/dispatcher/resource-source/structure.ts
@@ -3,7 +3,7 @@ import {getDangerMatrix} from 'utils/cost-matrix';
 
 declare global {
 	interface StructureSourceTask extends ResourceSourceTask {
-		target: Id<AnyStoreStructure>;
+		target: Id<AnyStoreStructure> | Id<Ruin | Tombstone>;
 	}
 }
 

--- a/src/role/transporter.ts
+++ b/src/role/transporter.ts
@@ -454,26 +454,17 @@ export default class TransporterRole extends Role {
 	 */
 	getAvailableSources(): TransporterSourceOrderOption[] {
 		const creep = this.creep;
-		const options = this.getAvailableEnergySources();
+		const options: TransporterSourceOrderOption[] = [];
 
 		const terminal = creep.room.terminal;
 		const storage = creep.room.storage;
 
-		// Don't pick up anything that's not energy if there's no place to store.
-		if (!terminal && !storage) return options;
-
 		const dispatcherTask = creep.room.sourceDispatcher.getTask({
 			creep,
-			resourceType: null,
+			// Don't pick up anything that's not energy if there's no place to store.
+			resourceType: (!terminal && !storage)? RESOURCE_ENERGY:null,
 		});
 		if (dispatcherTask) options.push(dispatcherTask);
-
-		this.addObjectResourceOptions(options, FIND_DROPPED_RESOURCES, 'resource');
-		this.addObjectResourceOptions(options, FIND_TOMBSTONES, 'tombstone');
-		this.addObjectResourceOptions(options, FIND_RUINS, 'tombstone');
-		this.addContainerResourceOptions(options);
-		this.addHighLevelResourceOptions(options);
-		this.addEvacuatingRoomResourceOptions(options);
 
 		return options;
 	}
@@ -486,296 +477,15 @@ export default class TransporterRole extends Role {
 	 */
 	getAvailableEnergySources(): TransporterSourceOrderOption[] {
 		const creep = this.creep;
-		const room = creep.room;
 		const options: TransporterSourceOrderOption[] = [];
 
 		const task = creep.room.sourceDispatcher.getTask({
 			creep,
-			resourceType: RESOURCE_ENERGY,
+			resourceType: RESOURCE_ENERGY
 		});
 		if (task) options.push(task);
 
-		let priority = 0;
-		if (room.energyAvailable < room.energyCapacityAvailable * 0.9) {
-			// Spawning is important, so get energy when needed.
-			priority = 4;
-		}
-		else if (room.terminal && room.storage && room.storage.store.energy > 5000 && room.terminal.store.energy < room.storage.store.energy * 0.05 && !room.isClearingTerminal()) {
-			// Take some energy out of storage to put into terminal from time to time.
-			priority = 2;
-		}
-
-		this.addObjectEnergySourceOptions(options, FIND_DROPPED_RESOURCES, 'resource', priority);
-		this.addObjectEnergySourceOptions(options, FIND_TOMBSTONES, 'tombstone', priority);
-		this.addObjectEnergySourceOptions(options, FIND_RUINS, 'tombstone', priority);
-
 		return options;
-	}
-
-	/**
-	 * Adds options for picking up energy from room objects to priority list.
-	 *
-	 * @param {Array} options
-	 *   A list of potential energy sources.
-	 * @param {String} findConstant
-	 *   The type of find operation to run, e.g. FIND_DROPPED_RESOURCES.
-	 * @param {string} optionType
-	 *   Type designation of added resource options.
-	 */
-	addObjectEnergySourceOptions(options: TransporterSourceOrderOption[], findConstant: FIND_RUINS | FIND_TOMBSTONES | FIND_DROPPED_RESOURCES, optionType: 'resource' | 'tombstone', storagePriority: number) {
-		const creep = this.creep;
-
-		// Get storage location, since that is a low priority source for transporters.
-		const storagePosition = creep.room.getStorageLocation();
-
-		// Look for energy on the ground.
-		const targets = creep.room.find(findConstant, {
-			filter: target => {
-				const store = target instanceof Resource ? {[target.resourceType]: target.amount} : target.store;
-				if ((store[RESOURCE_ENERGY] || 0) < 20) return false;
-				if (!this.isSafePosition(creep, target.pos)) return false;
-
-				// Const result = PathFinder.search(creep.pos, target.pos);
-				// if (result.incomplete) return false;
-
-				return true;
-			},
-		});
-
-		for (const target of targets) {
-			const store = target instanceof Resource ? {[target.resourceType]: target.amount} : target.store;
-			const option = {
-				priority: 4,
-				weight: store[RESOURCE_ENERGY] / 100, // @todo Also factor in distance.
-				type: optionType,
-				object: target,
-				resourceType: RESOURCE_ENERGY,
-			};
-
-			if (storagePosition && target.pos.x === storagePosition.x && target.pos.y === storagePosition.y) {
-				option.priority = creep.memory.role === 'transporter' ? storagePriority : 5;
-			}
-			else {
-				if (store[RESOURCE_ENERGY] < 100) option.priority--;
-				if (store[RESOURCE_ENERGY] < 200) option.priority--;
-
-				// If spawn / extensions need filling, transporters should not pick up
-				// energy from random targets as readily, instead prioritize storage.
-				if (creep.room.energyAvailable < creep.room.energyCapacityAvailable && creep.room.getCurrentResourceAmount(RESOURCE_ENERGY) > 5000 && creep.memory.role === 'transporter') option.priority -= 2;
-			}
-
-			if (store[RESOURCE_ENERGY] < creep.store.getCapacity() * 2) {
-				option.priority -= creep.room.getCreepsWithOrder('getEnergy', target.id).length * 3;
-				option.priority -= creep.room.getCreepsWithOrder('getResource', target.id).length * 3;
-			}
-
-			if (creep.room.storage && creep.room.getFreeStorage() < store[RESOURCE_ENERGY] && creep.room.getEffectiveAvailableEnergy() > 20_000) {
-				// If storage is super full, try leaving stuff on the ground.
-				option.priority -= 2;
-			}
-
-			options.push(option);
-		}
-	}
-
-	/**
-	 * Adds options for picking up resources from certain objects to priority list.
-	 *
-	 * @param {Array} options
-	 *   A list of potential resource sources.
-	 * @param {String} findConstant
-	 *   The type of find operation to run, e.g. FIND_DROPPED_RESOURCES.
-	 * @param {string} optionType
-	 *   Type designation of added resource options.
-	 */
-	addObjectResourceOptions(options: TransporterSourceOrderOption[], findConstant: FIND_RUINS | FIND_TOMBSTONES | FIND_DROPPED_RESOURCES, optionType: 'resource' | 'tombstone') {
-		const creep = this.creep;
-
-		// Look for resources on the ground.
-		const targets = creep.room.find(findConstant, {
-			filter: target => {
-				if (!this.isSafePosition(creep, target.pos)) return false;
-
-				const storeAmount = target instanceof Resource ? target.amount : target.store.getUsedCapacity();
-				if (storeAmount > 10) {
-					const result = PathFinder.search(creep.pos, target.pos);
-					if (!result.incomplete) return true;
-				}
-
-				return false;
-			},
-		});
-
-		for (const target of targets) {
-			const store = target instanceof Resource ? {[target.resourceType]: target.amount} : target.store;
-			for (const resourceType of getResourcesIn(store)) {
-				if (resourceType === RESOURCE_ENERGY) continue;
-				if (store[resourceType] === 0) continue;
-
-				const option = {
-					priority: 4,
-					weight: store[resourceType] / 30, // @todo Also factor in distance.
-					type: optionType,
-					object: target,
-					resourceType,
-				};
-
-				if (resourceType === RESOURCE_POWER) {
-					option.priority++;
-				}
-
-				if (creep.room.getFreeStorage() < store[resourceType]) {
-					// If storage is super full, try leaving stuff on the ground.
-					continue;
-				}
-
-				if (store[resourceType] < creep.store.getCapacity() * 2) {
-					option.priority -= creep.room.getCreepsWithOrder('getEnergy', target.id).length * 2;
-					option.priority -= creep.room.getCreepsWithOrder('getResource', target.id).length * 2;
-				}
-
-				options.push(option);
-			}
-		}
-	}
-
-	/**
-	 * Adds options for picking up resources from containers to priority list.
-	 *
-	 * @param {Array} options
-	 *   A list of potential resource sources.
-	 */
-	addContainerResourceOptions(options: TransporterSourceOrderOption[]) {
-		const room = this.creep.room;
-		// We need a decent place to store these resources.
-		if (!room.terminal && !room.storage) return;
-
-		// Take non-energy out of containers.
-		const containers = _.filter(
-			room.structuresByType[STRUCTURE_CONTAINER],
-			structure => this.isSafePosition(this.creep, structure.pos),
-		);
-
-		for (const container of containers) {
-			for (const resourceType of getResourcesIn(container.store)) {
-				if (resourceType === RESOURCE_ENERGY) continue;
-				if (container.store[resourceType] === 0) continue;
-
-				let isEmptyMineralContainer = false;
-				for (const mineral of room.minerals) {
-					if (
-						container.id === mineral.getNearbyContainer()?.id
-						&& resourceType === mineral.mineralType
-						&& container.store[resourceType] < CONTAINER_CAPACITY / 2
-					) {
-						isEmptyMineralContainer = true;
-						break;
-					}
-				}
-
-				if (isEmptyMineralContainer) continue;
-
-				const option: TransporterStructureOrderOption = {
-					priority: 3,
-					weight: container.store[resourceType] / 20, // @todo Also factor in distance.
-					type: 'structure',
-					object: container,
-					resourceType,
-				};
-
-				option.priority -= room.getCreepsWithOrder('getResource', container.id).length * 2;
-
-				options.push(option);
-			}
-		}
-	}
-
-	/**
-	 * Adds options for picking up resources for nukers and power spawns.
-	 *
-	 * @param {Array} options
-	 *   A list of potential resource sources.
-	 */
-	addHighLevelResourceOptions(options: TransporterSourceOrderOption[]) {
-		const room = this.creep.room;
-		if (room.isEvacuating()) return;
-
-		// Take ghodium if nuker needs it.
-		if (room.nuker && room.nuker.store.getFreeCapacity(RESOURCE_GHODIUM) > 0) {
-			const target = room.getBestStorageSource(RESOURCE_GHODIUM);
-			if (target && target.store[RESOURCE_GHODIUM] > 0) {
-				const option = {
-					priority: 2,
-					weight: 0, // @todo Also factor in distance.
-					type: 'structure',
-					object: target,
-					resourceType: RESOURCE_GHODIUM,
-				};
-
-				options.push(option);
-			}
-		}
-
-		// Take power if power spawn needs it.
-		if (room.powerSpawn && room.powerSpawn.store[RESOURCE_POWER] < room.powerSpawn.store.getCapacity(RESOURCE_POWER) * 0.1 && balancer.maySpendEnergyOnPowerProcessing()) {
-			const target = room.getBestStorageSource(RESOURCE_POWER);
-			if (target && target.store[RESOURCE_POWER] > 0) {
-				// @todo Limit amount since power spawn can only hold 100 power at a time.
-				// @todo Make sure only 1 creep does this at a time.
-				const option = {
-					priority: 3,
-					weight: 0, // @todo Also factor in distance.
-					type: 'structure',
-					object: target,
-					resourceType: RESOURCE_POWER,
-				};
-
-				if (room.isFullOnPower()) {
-					option.priority++;
-				}
-
-				options.push(option);
-			}
-		}
-	}
-
-	/**
-	 * Adds options for picking up resources for moving to terminal.
-	 *
-	 * @param {Array} options
-	 *   A list of potential resource sources.
-	 */
-	addEvacuatingRoomResourceOptions(options: TransporterSourceOrderOption[]) {
-		const room = this.creep.room;
-		if (!room.isEvacuating()) return;
-
-		// Take everything out of labs.
-		const labs = room.myStructuresByType[STRUCTURE_LAB] || [];
-		for (const lab of labs) {
-			if (room.boostManager.isLabUsedForBoosting(lab.id)) continue;
-
-			if (lab.store[RESOURCE_ENERGY] > 0) {
-				options.push({
-					priority: 3,
-					weight: 0,
-					type: 'structure',
-					object: lab,
-					resourceType: RESOURCE_ENERGY,
-				});
-			}
-
-			if (lab.mineralType) {
-				options.push({
-					priority: 3,
-					weight: 0,
-					type: 'structure',
-					object: lab,
-					resourceType: lab.mineralType,
-				});
-			}
-		}
-
-		// @todo Destroy nuker once storage is empty so we can pick up contained resources.
 	}
 
 	/**


### PR DESCRIPTION
I noticed the bot was running out of memory running on my private server and thought the transporter role was causing some of it.

Nukers and Power Spawns are already in the dispatcher system and just needed Drops, Tombstones and Ruins to complete it to clean up the transporter code.

Probably needs more testing for setting priority correctly but should make it a bit cleaner.

Merge or not I don't mind :). Just doing some contributing to open source that I use for testing.