### PR TITLE
Add check for isUnderAttack()  during dismantler spawn

### DIFF
--- a/src/spawn-role/dismantler.ts
+++ b/src/spawn-role/dismantler.ts
@@ -90,6 +90,8 @@ export default class DismantlerSpawnRole extends SpawnRole {
 
 			for (const sourceLocation of locations) {
 				if (!operation.needsDismantler(sourceLocation)) continue;
+				// Prevent continuous dismantler suicide. 
+				if (operation.isUnderAttack()) continue;
 
 				const dismantlerCount = _.filter(Game.creepsByRole.dismantler || [], (creep: DismantlerCreep) => creep.memory.source === sourceLocation).length;
 				if (dismantlerCount > 0) continue;


### PR DESCRIPTION
Since potentially dismantlers are continuously spawned and run into a room full of enemies to be killed, I have added this check.

Potentially this prevents the expansion into a remote mine if a wall has to be removed to start the mine. In this case, however, the dismantler should get escort protection.