### PR TITLE
Use console.logUnsafe for HTML-containing log output

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -62,7 +62,7 @@ const utilities = {
 			}
 
 			Game.notify(error.name + ' in ' + errorLocation + ':<br>' + stackTrace);
-			console.log('<span style="color:red">' + error.name + ' in ' + errorLocation + ':<br>' + stackTrace + '</span>');
+			console.logUnsafe('<span style="color:red">' + error.name + ' in ' + errorLocation + ':<br>' + stackTrace + '</span>');
 		}
 
 		return null;

--- a/src/utils/ErrorMapper.ts
+++ b/src/utils/ErrorMapper.ts
@@ -92,11 +92,11 @@ export class ErrorMapper {
 				if (error instanceof Error) {
 					if ('sim' in Game.rooms || !this.consumer) {
 						const message = 'Source maps don\'t work in the simulator - displaying original error';
-						console.log(`<span style='color:red'>${message}<br>${_.escape(error.stack)}</span>`);
+						console.logUnsafe(`<span style='color:red'>${message}<br>${_.escape(error.stack)}</span>`);
 					}
 					else {
 						const message = _.escape(this.sourceMappedStackTrace(error));
-						console.log(`<span style='color:red'>${message}</span>`);
+						console.logUnsafe(`<span style='color:red'>${message}</span>`);
 						Game.notify(message);
 					}
 				}


### PR DESCRIPTION
## Summary
- Replace `console.log()` with `console.logUnsafe()` in 3 places where HTML tags (`<span>`, `<font>`) are used in log output
- Fixes raw HTML rendering as text in the game console after the Screeps V8 engine update that sanitizes HTML in `console.log()`

## Files Changed
- `src/utilities.ts` — Error handler red span output
- `src/utils/ErrorMapper.ts` — Source-mapped error display (2 instances)

Note: The Logger class in `src/utils/debug.ts` already uses `logUnsafe` on this branch.

## Test plan
- [x] Verified HTML-colored log output renders correctly on a private server
- [x] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)